### PR TITLE
PPT-5280 - add status field to user edit screen

### DIFF
--- a/src/admin/UserAdmin.php
+++ b/src/admin/UserAdmin.php
@@ -78,6 +78,13 @@ class UserAdmin extends Admin
 			$mapper->password('password_confirmation')
 				->label(trans('bauhaususer::admin.users.form.password-confirm.label'))
 				->placeholder(trans('bauhaususer::admin.users.form.password-confirm.placeholder'));
+
+			$mapper->select('is_active')
+				->label(trans('bauhaususer::admin.users.form.status.label'))
+				->options( [
+					0 => "Inactive",
+					1 => "Active"
+				] );
 		});
 
 		$mapper->tab(trans('bauhaususer::admin.users.form.tabs.info'), function ($mapper) {

--- a/src/lang/en/admin.php
+++ b/src/lang/en/admin.php
@@ -52,6 +52,9 @@ return [
 			],
 			'groups' => [
 				'label' => 'Groups'
+			],
+			'status' => [
+				'label' => 'Status'
 			]
 		],
 		'filter' => [


### PR DESCRIPTION
Admin users were being created with an inactive status and edit screen had no way to update this value.
